### PR TITLE
Optimize DocCard and PaginationLink styles

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   "dependencies": {
     "@docusaurus/core": "2.4.1",
     "@docusaurus/preset-classic": "2.4.1",
+    "@docusaurus/theme-common": "^2.4.1",
     "@mdx-js/react": "^1.6.22",
     "clsx": "^1.2.1",
     "prism-react-renderer": "^1.3.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ dependencies:
   '@docusaurus/preset-classic':
     specifier: 2.4.1
     version: 2.4.1(@algolia/client-search@4.19.1)(react-dom@17.0.2)(react@17.0.2)(search-insights@2.8.1)(typescript@4.7.4)
+  '@docusaurus/theme-common':
+    specifier: ^2.4.1
+    version: 2.4.1(@docusaurus/types@2.4.1)(react-dom@17.0.2)(react@17.0.2)(typescript@4.7.4)
   '@mdx-js/react':
     specifier: ^1.6.22
     version: 1.6.22(react@17.0.2)
@@ -529,7 +532,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.9
-      '@babel/helper-plugin-utils': 7.10.4
+      '@babel/helper-plugin-utils': 7.22.5
       '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.12.9)
       '@babel/plugin-transform-parameters': 7.22.5(@babel/core@7.12.9)
     dev: false

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -123,6 +123,14 @@ nav.menu {
   margin-left: 1rem;
 }
 
+/* Pagination */
+.pagination-nav__link--prev .pagination-nav__label::before {
+  content: none;
+}
+.pagination-nav__link--next .pagination-nav__label::after {
+  content: none;
+}
+
 /* Doc Content */
 .markdown > h1,
 .markdown > h2,

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -124,6 +124,12 @@ nav.menu {
 }
 
 /* Pagination */
+.pagination-nav__label {
+  color: var(--ifm-font-color-base);
+}
+.pagination-nav__sublabel {
+  color: var(--ifm-toc-link-color);
+}
 .pagination-nav__link--prev .pagination-nav__label::before {
   content: none;
 }

--- a/src/theme/DocCard/index.js
+++ b/src/theme/DocCard/index.js
@@ -1,0 +1,80 @@
+import React from 'react';
+import clsx from 'clsx';
+import Link from '@docusaurus/Link';
+import { findFirstCategoryLink, useDocById } from '@docusaurus/theme-common/internal';
+import isInternalUrl from '@docusaurus/isInternalUrl';
+import { translate } from '@docusaurus/Translate';
+import styles from './styles.module.css';
+function CardContainer({href, children}) {
+  return (
+    <Link
+      href={href}
+      className={clsx('card', styles.cardContainer)}>
+      {children}
+    </Link>
+  );
+}
+function CardLayout({href, icon, title, description}) {
+  return (
+    <CardContainer href={href}>
+      <h2 className={clsx('text--truncate', styles.cardTitle)} title={title}>
+        {icon} {title}
+      </h2>
+      {description && (
+        <p
+          className={clsx('text--truncate', styles.cardDescription)}
+          title={description}>
+          {description}
+        </p>
+      )}
+    </CardContainer>
+  );
+}
+function CardCategory({item}) {
+  const href = findFirstCategoryLink(item);
+  // Unexpected: categories that don't have a link have been filtered upfront
+  if (!href) {
+    return null;
+  }
+  return (
+    <CardLayout
+      href={href}
+      icon="🗃️"
+      title={item.label}
+      description={
+        item.description ??
+        translate(
+          {
+            message: '{count} items',
+            id: 'theme.docs.DocCard.categoryDescription',
+            description:
+              'The default description for a category card in the generated index about how many items this category includes',
+          },
+          {count: item.items.length},
+        )
+      }
+    />
+  );
+}
+function CardLink({item}) {
+  const icon = isInternalUrl(item.href) ? '📄️' : '🔗';
+  const doc = useDocById(item.docId ?? undefined);
+  return (
+    <CardLayout
+      href={item.href}
+      icon={icon}
+      title={item.label}
+      description={item.description ?? doc?.description}
+    />
+  );
+}
+export default function DocCard({item}) {
+  switch (item.type) {
+    case 'link':
+      return <CardLink item={item} />;
+    case 'category':
+      return <CardCategory item={item} />;
+    default:
+      throw new Error(`unknown item type ${JSON.stringify(item)}`);
+  }
+}

--- a/src/theme/DocCard/styles.module.css
+++ b/src/theme/DocCard/styles.module.css
@@ -6,9 +6,9 @@
   transition: none;
   box-shadow: none;
   padding: 1.5rem;
+  transition-property: border, box-shadow;
   border: 1px solid var(--ifm-toc-border-color);
   background-color: var(--ifm-sidebar-background-color);
-  transition-property: border, box-shadow;
 }
 
 .cardContainer:hover {
@@ -21,21 +21,9 @@
 
 .cardTitle {
   font-size: 1.2rem;
-  display: flex;
-  align-items: center;
 }
 
 .cardDescription {
-  hyphens: auto;
-  overflow: hidden;
-  display: -webkit-box;
-  -webkit-line-clamp: 3;
-  -webkit-box-orient: vertical;
+  font-size: 0.8rem;
   color: var(--ifm-font-color-base);
-}
-
-.cardIcon {
-  width: 24px;
-  height: 24px;
-  margin-right: 8px;
 }


### PR DESCRIPTION
### Changes
- Swizzle `DocCard` and unify the style of cards in auto-generated pages
- Simplify the layout of `PaginationLink`

### Comparation

Before:
![image](https://github.com/sporeprotocol/spore-docs/assets/44739165/8f2aa309-f829-4d6c-9cdb-98cc4d038397)

After:
![image](https://github.com/sporeprotocol/spore-docs/assets/44739165/06a696bf-1ce2-481e-bd67-bdd19a15b557)

