### PR TITLE
Sync "on-chain blog tutorial" relevant content

### DIFF
--- a/docs/tutorials/create-first-spore/explore-code.md
+++ b/docs/tutorials/create-first-spore/explore-code.md
@@ -274,3 +274,5 @@ Additional resources for your reference:
 ## What's next?
 
 For more practical recipes on how to use the Spore SDK, visit: [How-to Recipes](/category/how-to-recipes).
+
+If you are a dapp developer, feel free to try out building an on-chain blog app with Spore: [Create Simple On-Chain Blog](/tutorials/create-on-chain-blog).


### PR DESCRIPTION
### Changes
- The "explore the code" doc has been incorrectly reverted, re-syncing the content