### PR TITLE
upload new recipes

### DIFF
--- a/docs/basics/spore-tech-def.mdx
+++ b/docs/basics/spore-tech-def.mdx
@@ -14,7 +14,7 @@ There are two defined cell types: `Spore Cell` and `Spore Cluster Cell`, of whic
 As illustrated above,
 
 - Multiple Spores cells (Spore #1, #2) can be assigned to a Cluster (Cluster #1)
-- A single Spore cell (Spore #4) can be assigned to a cluster (Cluster #2)
+- A single Spore cell (Spore #4) can be assigned to a Cluster (Cluster #2)
 - A standalone Spore cell can exist without being associated with any Cluster (Spore #3)
 - A Spore cell cannot be assigned to multiple Clusters
 

--- a/docs/recipes/config-0-fee-transfer.md
+++ b/docs/recipes/config-0-fee-transfer.md
@@ -1,0 +1,44 @@
+---
+sidebar_position: 9
+---
+
+# Configure Zero-fee Transfer Feature
+
+Every spore, when created, is fueled with 1 CKBytes as “gas” that covers about `100,000` future transactions. This default setting, referred as the  [Zero-fee Transfer](/basics/spore-101#do-i-need-to-hold-ckb-to-transfer-and-receive-spores) feature enables recipients to transact spores without additional costs.
+
+## Configure Zero-fee Transfer Feature
+
+If you want to modify this feature by adding additional CKBytes, or if the spore was created without the capacity margin, you can utilize the `transferSpore` API to "refuel":
+
+```tsx
+import { transferSpore } from '@spore-sdk/core';
+import { BI } from '@ckb-lumos/lumos';
+
+let { txSkeleton } = await transferSpore({
+  outPoint: SPORE_OUTPOINT,
+  toLock: OWNER_LOCK,
+  fromInfos: [OWNER_ADDRESS],
+  // highlight-start
+  capacityMargin: BI.from(1_0000_0000), // Add 1 CKB as margin, default is 0
+  useCapacityMarginAsFee: false, // Disable the feature
+  // highlight-end
+});
+```
+
+- `outPoint` - Specifies the target spore for configuration, identified by its transaction hash and index.
+- `toLock` - The lock script of the new owner/recipient of the spore (which remains with the original owner in this case).
+- `fromInfos` - The transaction's sponsor, specifies where to collect capacity from.
+- `capacityMargin` - Capacity allocated as future transaction fees.
+- `useCapacityMarginAsFee`- Specifies whether to pay fee with the target spore's capacity margin, default to "true", if false, the transaction is paid with capacity collected from the `fromInfos`
+
+Essentially, you:
+
+1. Transfer the spore to the owner itself
+2. Set the `capacityMargin` to add additional capacity as margin
+3. Use wallet funds to pay for this transaction
+
+:::caution
+
+You can't set `capacityMargin` and have `useCapacityMarginAsFee` as true at the same time.
+
+:::

--- a/docs/recipes/create-private-cluster.mdx
+++ b/docs/recipes/create-private-cluster.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 5
+sidebar_position: 3
 ---
 
 import EmbedCard from "@site/src/components/EmbedCard";
@@ -30,7 +30,7 @@ let { txSkeleton } = await createCluster({
 
 - `data` - The cluster's data, including name and description.
 - `toLock` - The lock script specifies the new cluster's ownership.
-- `fromInfos` - The transaction's sponsors, specifies where to collect capacity from.
+- `fromInfos` - The transaction's sponsor, specifies where to collect capacity from.
 
 ## Extras
 

--- a/docs/recipes/create-private-cluster.mdx
+++ b/docs/recipes/create-private-cluster.mdx
@@ -24,13 +24,13 @@ let { txSkeleton } = await createCluster({
     description: 'Description of the cluster',
   },
   toLock: OWNER_LOCK,
-  fromInfos: [ONWER_ADDRESS],
+  fromInfos: [SPONSOR_ADDRESS],
 });
 ```
 
 - `data` - The cluster's data, including name and description.
 - `toLock` - The lock script specifies the new cluster's ownership.
-- `fromInfos` - The transaction's sponsor, specifies where to collect capacity from.
+- `fromInfos` - The transaction's sponsors, specifies where to collect capacity from.
 
 ## Extras
 

--- a/docs/recipes/create-private-cluster.mdx
+++ b/docs/recipes/create-private-cluster.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 4
+sidebar_position: 5
 ---
 
 import EmbedCard from "@site/src/components/EmbedCard";

--- a/docs/recipes/create-pubic-cluster.mdx
+++ b/docs/recipes/create-pubic-cluster.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 5
+sidebar_position: 4
 ---
 
 import EmbedCard from "@site/src/components/EmbedCard";

--- a/docs/recipes/create-spore-with-cluster.md
+++ b/docs/recipes/create-spore-with-cluster.md
@@ -33,7 +33,7 @@ let { txSkeleton } = await createSpore({
     clusterId: CLUSTER_ID,
   },
   toLock: OWNER_LOCK,
-  fromInfos: [OWNER_ADDRESS],
+  fromInfos: [SPONSOR_ADDRESS],
 });
 ```
 

--- a/docs/recipes/create-spore-with-cluster.md
+++ b/docs/recipes/create-spore-with-cluster.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 7
+sidebar_position: 5
 ---
 
 # Create Spore With Cluster

--- a/docs/recipes/create-spore.mdx
+++ b/docs/recipes/create-spore.mdx
@@ -44,7 +44,7 @@ Here's a code example for how to create a spore with [`CKB default lock`](https:
   className="margin-top--sm"
 />
 
-### Configure the Zero-fee Transfer feature
+### Modify the Zero-fee Transfer feature
 
 The Zero-fee Transfer feature is enabled by reserving a small amount of CKBytes as fee for future transactions. When creating a spore, the default is to allocate 1 CKB (100,000,000 shannons) as capacity margin. To adjust the margin amount for the new spore, you can set the `capacityMargin` prop, for example, to 2 CKB like this:
 

--- a/docs/recipes/create-spore.mdx
+++ b/docs/recipes/create-spore.mdx
@@ -21,13 +21,13 @@ let { txSkeleton } = await createSpore({
     content: CONTENT_AS_BYTES,
   },
   toLock: OWNER_LOCK,
-  fromInfos: [OWNER_ADDRESS],
+  fromInfos: [SPONSOR_ADDRESS],
 });
 ```
 
 - `data` - The spore's data, including file data relevant properties.
 - `toLock` - The lock script specifies the spore's ownership.
-- `fromInfos` - The transaction's sponsor, specifies where to collect capacity from.
+- `fromInfos` - The transaction's sponsors, specifies where to collect capacity from.
 
 ## Extras
 
@@ -46,7 +46,7 @@ Here's a code example for how to create a spore with [`CKB default lock`](https:
 
 ### Modify the Zero-fee Transfer feature
 
-The Zero-fee Transfer feature is enabled by reserving a small amount of CKBytes as fee for future transactions. When creating a spore, the default is to allocate 1 CKB (100,000,000 shannons) as capacity margin. To adjust the margin amount for the new spore, you can set the `capacityMargin` prop, for example, to 2 CKB like this:
+The Zero-fee Transfer feature enables recipients to transact spores without additional costs by reserving a tiny amount of CKBytes as fee for future transactions. When creating a spore, the default is to allocate 1 CKB (100,000,000 shannons) as capacity margin to covers about 100,000 future transaction. To adjust the margin amount for the new spore, you can set the `capacityMargin` prop, for example, to 2 CKB like this:
 
 ```tsx
 import { createSpore } from '@spore-sdk/core';

--- a/docs/recipes/create-spore.mdx
+++ b/docs/recipes/create-spore.mdx
@@ -27,7 +27,7 @@ let { txSkeleton } = await createSpore({
 
 - `data` - The spore's data, including file data relevant properties.
 - `toLock` - The lock script specifies the spore's ownership.
-- `fromInfos` - The transaction's sponsors, specifies where to collect capacity from.
+- `fromInfos` - The transaction's sponsor, specifies where to collect capacity from.
 
 ## Extras
 
@@ -43,6 +43,22 @@ Here's a code example for how to create a spore with [`CKB default lock`](https:
   description="Create a Spore on-chain with CKB default lock"
   className="margin-top--sm"
 />
+
+### Configure the Zero-fee Transfer feature
+
+The Zero-fee Transfer feature is enabled by reserving a small amount of CKBytes as fee for future transactions. When creating a spore, the default is to allocate 1 CKB (100,000,000 shannons) as capacity margin. To adjust the margin amount for the new spore, you can set the `capacityMargin` prop, for example, to 2 CKB like this:
+
+```tsx
+import { createSpore } from '@spore-sdk/core';
+  // highlight-next-line
+import { BI } from '@ckb-lumos/lumos';
+
+let { txSkeleton } = await createSpore({
+  ...
+  // highlight-next-line
+  capacityMargin: BI.from(2_0000_0000), // 2 CKB
+});
+```
 
 ### Configure transaction size limits
 

--- a/docs/recipes/create-spore.mdx
+++ b/docs/recipes/create-spore.mdx
@@ -46,7 +46,7 @@ Here's a code example for how to create a spore with [`CKB default lock`](https:
 
 ### Modify the Zero-fee Transfer feature
 
-The Zero-fee Transfer feature enables recipients to transact spores without additional costs by reserving a tiny amount of CKBytes as fee for future transactions. When creating a spore, the default is to allocate 1 CKB (100,000,000 shannons) as capacity margin to covers about 100,000 future transaction. To adjust the margin amount for the new spore, you can set the `capacityMargin` prop, for example, to 2 CKB like this:
+The Zero-fee Transfer feature enables recipients to transact spores without additional costs by reserving a tiny amount of CKBytes as fee for future transactions. When creating a spore, the default is to allocate 1 CKB (100,000,000 shannons) as capacity margin to cover about 100,000 future transaction. To adjust the margin amount for the new spore, you can set the `capacityMargin` prop, for example, to 2 CKB like this:
 
 ```tsx
 import { createSpore } from '@spore-sdk/core';

--- a/docs/recipes/disable-0-fee-transfer.md
+++ b/docs/recipes/disable-0-fee-transfer.md
@@ -51,7 +51,7 @@ let { txSkeleton } = await transferSpore({
   },
   toLock: RECEIVER_LOCK_SCRIPT,
     // highlight-next-line
-  fromInfos: [OWNER_ADDRESS],
+  fromInfos: [SPONSOR_ADDRESS],
     // highlight-next-line
   useCapacityMarginAsFee: false,
 });

--- a/docs/recipes/disable-0-fee-transfer.md
+++ b/docs/recipes/disable-0-fee-transfer.md
@@ -59,6 +59,6 @@ let { txSkeleton } = await transferSpore({
 
 - `outPoint` - Specifies the target spore for the transfer, identified by its transaction hash and index.
 - `toLock` - The lock script of the new owner/recipient of the spore.
-- `fromInfos` - The transaction's sponsor, specifies where to collect capacity from.
+- `fromInfos` - The transaction's sponsors, specifies where to collect capacity from.
 - `useCapacityMarginAsFee`- Specifies whether to pay fee with the target spore's capacity margin. The default is "true," and if set to "false," the transaction fee will be collected from the `fromInfos`.
 

--- a/docs/recipes/disable-0-fee-transfer.md
+++ b/docs/recipes/disable-0-fee-transfer.md
@@ -28,7 +28,7 @@ let { txSkeleton } = await createSpore({
 
 - `data` - The spore's data, including file data relevant properties.
 - `toLock` - The lock script specifies the spore's ownership.
-- `fromInfos` - The transaction's sponsor, specifies where to collect capacity from.
+- `fromInfos` - The transaction's sponsors, specifies where to collect capacity from.
 - `capacityMargin` - Additional capacity allocated as future transaction fees. By setting it to zero, indicates no additional capacity is allocated for transaction fees, thus turning off the “Zero-fee Transfer” feature for the spore being created.
 
 :::info

--- a/docs/recipes/disable-0-fee-transfer.md
+++ b/docs/recipes/disable-0-fee-transfer.md
@@ -2,7 +2,7 @@
 sidebar_position: 9
 ---
 
-# Disable Zero-fee Transfer Feature
+# Disable Zero-fee Transfer
 
 By default, Spores are created with the [Zero-fee Transfer](/basics/spore-101#do-i-need-to-hold-ckb-to-transfer-and-receive-spores) feature enabled, allowing the receiver to interact with the Spore without the need to possess or deposit additional tokens in their wallet. However, you have the flexibility to disable or enable this feature during Spore/Cluster ***creation*** and ***transfer***, depending on your specific application needs.
 

--- a/docs/recipes/disable-0-fee-transfer.md
+++ b/docs/recipes/disable-0-fee-transfer.md
@@ -20,7 +20,7 @@ let { txSkeleton } = await createSpore({
     content: CONTENT_AS_BYTES,
   },
   toLock: OWNER_LOCK,
-  fromInfos: [OWNER_ADDRESS],
+  fromInfos: [SPONSOR_ADDRESS],
     // highlight-next-line
   capacityMargin: BI.from(0), // No capacity margin will be added
 });

--- a/docs/recipes/disable-0-fee-transfer.md
+++ b/docs/recipes/disable-0-fee-transfer.md
@@ -1,0 +1,64 @@
+---
+sidebar_position: 9
+---
+
+# Disable Zero-fee Transfer Feature
+
+By default, Spores are created with the [Zero-fee Transfer](/basics/spore-101#do-i-need-to-hold-ckb-to-transfer-and-receive-spores) feature enabled, allowing the receiver to interact with the Spore without the need to possess or deposit additional tokens in their wallet. However, you have the flexibility to disable or enable this feature during Spore/Cluster ***creation*** and ***transfer***, depending on your specific application needs.
+
+## Disable “Zero-fee Transfer” During Creation
+
+When creating a new Spore/Cluster, it comes with a capacity margin of `1 CKB` (100,000,000 shannons) that can be used to cover fees for 100,000 future transactions. To disable the "Zero-fee Transfer" feature for the new Spore/Cluster, set the `capacityMargin` to `0` as follows:
+
+```tsx
+import { createSpore } from '@spore-sdk/core';
+import { BI } from '@ckb-lumos/lumos';
+
+let { txSkeleton } = await createSpore({
+  data: {
+    contentType: CONTENT_MIME_TYPE,
+    content: CONTENT_AS_BYTES,
+  },
+  toLock: OWNER_LOCK,
+  fromInfos: [OWNER_ADDRESS],
+    // highlight-next-line
+  capacityMargin: BI.from(0), // No capacity margin will be added
+});
+```
+
+- `data` - The spore's data, including file data relevant properties.
+- `toLock` - The lock script specifies the spore's ownership.
+- `fromInfos` - The transaction's sponsor, specifies where to collect capacity from.
+- `capacityMargin` - Additional capacity allocated as future transaction fees. By setting it to zero, indicates no additional capacity is allocated for transaction fees, thus turning off the “Zero-fee Transfer” feature for the spore being created.
+
+:::info
+
+If the sender attempts to transfer a Spore/Cluster with 0 capacity margin, they will need to pay the transaction fee from their wallet.
+
+:::
+
+## Disable “Zero-fee Transfer” During Transfer
+
+By default, when you transfer a Spore/Cluster, it automatically uses the capacity margin to cover the fees without any extra setup. However, to disable the “Zero-fee Transfer” feature and use wallet funds to pay the fee instead, you can set the `useCapacityMarginAsFee` to `false` and include a wallet address in the `fromInfos` prop.
+
+```tsx
+import { transferSpore } from '@spore-sdk/core';
+
+let { txSkeleton } = await transferSpore({
+  outPoint: {
+    txHash: '0x76cede56c91f8531df0e3084b3127686c485d08ad8e86ea948417094f3f023f9',
+    index: '0x0',
+  },
+  toLock: RECEIVER_LOCK_SCRIPT,
+    // highlight-next-line
+  fromInfos: [OWNER_ADDRESS],
+    // highlight-next-line
+  useCapacityMarginAsFee: false,
+});
+```
+
+- `outPoint` - Specifies the target spore for the transfer, identified by its transaction hash and index.
+- `toLock` - The lock script of the new owner/recipient of the spore.
+- `fromInfos` - The transaction's sponsor, specifies where to collect capacity from.
+- `useCapacityMarginAsFee`- Specifies whether to pay fee with the target spore's capacity margin. The default is "true," and if set to "false," the transaction fee will be collected from the `fromInfos`.
+

--- a/docs/recipes/handle-cluster-data.md
+++ b/docs/recipes/handle-cluster-data.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 7
+sidebar_position: 12
 ---
 
 # Encode/decode ClusterData

--- a/docs/recipes/handle-spore-data.md
+++ b/docs/recipes/handle-spore-data.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 3
+sidebar_position: 11
 ---
 
 # Encode/decode SporeData

--- a/docs/recipes/melt-spore.mdx
+++ b/docs/recipes/melt-spore.mdx
@@ -1,0 +1,47 @@
+---
+sidebar_position: 4
+---
+
+import EmbedCard from "@site/src/components/EmbedCard";
+
+# Melt Spore
+
+In this recipe, you will learn how to melt a [spore](/basics/spore-101#what-is-a-spore) back into its [locked up CKBytes](/basics/spore-101#is-there-a-cost-to-mint-a-spore).
+
+:::caution
+Immortal spores cannot be melted.
+:::
+
+## Melt a Spore
+
+You can melt a regular spore using the `meltSpore` API from [spore-sdk](https://docs.spore.pro/resources/spore-sdk):
+```tsx
+import { meltSpore } from '@spore-sdk/core';
+
+let { txSkeleton } = await meltSpore({
+  outPoint: {
+    txHash: '0x76cede56c91f8531df0e3084b3127686c485d08ad8e86ea948417094f3f023f9',
+    index: '0x0',
+  },
+  fromInfos: [OWNER_ADDRESS],
+});
+```
+
+- `outPoint` - Specifies the spore you want to melt, identified by its transaction hash and index.
+- `fromInfos` - The transaction's sponsor, specifies where to collect capacity from.
+
+## Extras
+
+### Code example
+
+For a valid on-chain transaction, you'll need to sign the transaction skeleton and send it to the chain.
+
+Here's a code example for how to melt a spore using [`CKB default lock`](https://github.com/nervosnetwork/ckb-system-scripts/blob/master/c/secp256k1_blake160_sighash_all.c):
+
+<EmbedCard
+  title="meltSpore.ts"
+  href="https://github.com/sporeprotocol/spore-sdk/blob/b3e5e9c8f0243567d6eb06f1b759b3e4829bacb9/examples/secp256k1/apis/destroySpore.ts"
+  description="Melt an on-chain Spore "
+  className="margin-top--sm"
+/>
+

--- a/docs/recipes/melt-spore.mdx
+++ b/docs/recipes/melt-spore.mdx
@@ -28,7 +28,7 @@ let { txSkeleton } = await meltSpore({
 ```
 
 - `outPoint` - Specifies the spore you want to melt, identified by its transaction hash and index.
-- `fromInfos` - The transaction's sponsor, specifies where to collect capacity from.
+- `fromInfos` - The transaction's sponsors, specifies where to collect capacity from.
 
 ## Extras
 

--- a/docs/recipes/melt-spore.mdx
+++ b/docs/recipes/melt-spore.mdx
@@ -23,7 +23,7 @@ let { txSkeleton } = await meltSpore({
     txHash: '0x76cede56c91f8531df0e3084b3127686c485d08ad8e86ea948417094f3f023f9',
     index: '0x0',
   },
-  fromInfos: [OWNER_ADDRESS],
+  fromInfos: [SPONSOR_ADDRESS],
 });
 ```
 

--- a/docs/recipes/melt-spore.mdx
+++ b/docs/recipes/melt-spore.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 4
+sidebar_position: 10
 ---
 
 import EmbedCard from "@site/src/components/EmbedCard";

--- a/docs/recipes/modify-0-fee-transfer.md
+++ b/docs/recipes/modify-0-fee-transfer.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 9
+sidebar_position: 8
 ---
 
 # Modify Zero-fee Transfer 

--- a/docs/recipes/modify-0-fee-transfer.md
+++ b/docs/recipes/modify-0-fee-transfer.md
@@ -27,7 +27,7 @@ let { txSkeleton } = await transferSpore({
 
 - `outPoint` - Specifies the target spore for configuration, identified by its transaction hash and index.
 - `toLock` - The lock script of the new owner/recipient of the spore (which remains with the original owner in this case).
-- `fromInfos` - The transaction's sponsor, specifies where to collect capacity from.
+- `fromInfos` - The transaction's sponsors, specifies where to collect capacity from.
 - `capacityMargin` - Capacity allocated as future transaction fees.
 - `useCapacityMarginAsFee`- Specifies whether to pay fee with the target spore's capacity margin, default to "true", if false, the transaction is paid with capacity collected from the `fromInfos`
 

--- a/docs/recipes/modify-0-fee-transfer.md
+++ b/docs/recipes/modify-0-fee-transfer.md
@@ -2,11 +2,11 @@
 sidebar_position: 9
 ---
 
-# Configure Zero-fee Transfer Feature
+# Modify Zero-fee Transfer 
 
 Every spore, when created, is fueled with 1 CKBytes as “gas” that covers about `100,000` future transactions. This default setting, referred as the  [Zero-fee Transfer](/basics/spore-101#do-i-need-to-hold-ckb-to-transfer-and-receive-spores) feature enables recipients to transact spores without additional costs.
 
-## Configure Zero-fee Transfer Feature
+## Modify Zero-fee Transfer Feature
 
 If you want to modify this feature by adding additional CKBytes, or if the spore was created without the capacity margin, you can utilize the `transferSpore` API to "refuel":
 

--- a/docs/recipes/modify-0-fee-transfer.md
+++ b/docs/recipes/modify-0-fee-transfer.md
@@ -17,7 +17,7 @@ import { BI } from '@ckb-lumos/lumos';
 let { txSkeleton } = await transferSpore({
   outPoint: SPORE_OUTPOINT,
   toLock: OWNER_LOCK,
-  fromInfos: [OWNER_ADDRESS],
+  fromInfos: [SPONSOR_ADDRESS],
   // highlight-start
   capacityMargin: BI.from(1_0000_0000), // Add 1 CKB as margin, default is 0
   useCapacityMarginAsFee: false, // Disable the feature

--- a/docs/recipes/modify-0-fee-transfer.md
+++ b/docs/recipes/modify-0-fee-transfer.md
@@ -4,7 +4,7 @@ sidebar_position: 8
 
 # Modify Zero-fee Transfer 
 
-Every spore, when created, is fueled with 1 CKBytes as “gas” that covers about `100,000` future transactions. This default setting, referred as the  [Zero-fee Transfer](/basics/spore-101#do-i-need-to-hold-ckb-to-transfer-and-receive-spores) feature enables recipients to transact spores without additional costs.
+Every spore, when created, is fueled with 1 CKByte as transaction fee that covers about `100,000` future transactions. This default setting, referred as the  [Zero-fee Transfer](/basics/spore-101#do-i-need-to-hold-ckb-to-transfer-and-receive-spores) feature enables recipients to transact spores without additional costs.
 
 ## Modify Zero-fee Transfer Feature
 

--- a/docs/recipes/transfer-cluster.mdx
+++ b/docs/recipes/transfer-cluster.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 8
+sidebar_position: 7
 ---
 
 import EmbedCard from "@site/src/components/EmbedCard";

--- a/docs/recipes/transfer-cluster.mdx
+++ b/docs/recipes/transfer-cluster.mdx
@@ -1,0 +1,44 @@
+---
+sidebar_position: 8
+---
+
+import EmbedCard from "@site/src/components/EmbedCard";
+
+# Transfer Cluster
+
+In this recipe, you will learn how to transfer ownership of a [cluster](/basics/spore-101#what-is-a-cluster) using the [spore-sdk](https://docs.spore.pro/resources/spore-sdk). Owning a cluster doesn’t grant ownership of the spores associated with that cluster.
+
+## Transfer a Cluster
+
+You can execute a transfer using the `transferCluster` API from spore-sdk:
+
+```tsx
+import { transferCluster } from '@spore-sdk/core';
+
+let { txSkeleton } = await transferCluster({
+  outPoint: {
+    txHash: '0xb1f94d7d8e8441bfdf1fc76639d12f4c3c391b8c8a18ed558e299674095290c3',
+    index: '0x0',
+  },
+  toLock: RECEIVER_LOCK_SCRIPT,
+});
+```
+
+- `outPoint` - Specifies the target cluster for the transfer, identified by its transaction hash and index.
+- `toLock` - The lock script of the new owner/recipient of the cluster.
+
+## Extras
+
+### Code example
+
+For a valid on-chain transaction, you'll need to sign the transaction and send it to the chain.
+
+Here's a code example for how to transfer a cluster with [`CKB default lock`](https://github.com/nervosnetwork/ckb-system-scripts/blob/master/c/secp256k1_blake160_sighash_all.c):
+
+<EmbedCard
+  title="transferCluster.ts"
+  href="https://github.com/sporeprotocol/spore-sdk/blob/b3e5e9c8f0243567d6eb06f1b759b3e4829bacb9/examples/secp256k1/apis/transferCluster.ts"
+  description="Transfer a Cluster "
+  className="margin-top--sm"
+/>
+

--- a/docs/recipes/transfer-spore.mdx
+++ b/docs/recipes/transfer-spore.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 3
+sidebar_position: 6
 ---
 
 import EmbedCard from "@site/src/components/EmbedCard";

--- a/docs/recipes/transfer-spore.mdx
+++ b/docs/recipes/transfer-spore.mdx
@@ -1,0 +1,45 @@
+---
+sidebar_position: 3
+---
+
+import EmbedCard from "@site/src/components/EmbedCard";
+
+# Transfer Spore
+
+In this recipe, you will learn how to transfer a [spore](/basics/spore-101#what-is-a-spore) to another owner. This process allows you to change the ownership of a spore.
+
+
+## Transfer a Spore
+
+You can execute a transfer using the `transferSpore` API from [spore-sdk](https://docs.spore.pro/resources/spore-sdk):
+
+```tsx
+import { transferSpore } from '@spore-sdk/core';
+
+let { txSkeleton } = await transferSpore({
+  outPoint: {
+    txHash: '0x76cede56c91f8531df0e3084b3127686c485d08ad8e86ea948417094f3f023f9',
+    index: '0x0',
+  },
+  toLock: RECEIVER_LOCK_SCRIPT,
+});
+```
+
+- `outPoint` - Specifies the target spore for the transfer, identified by its transaction hash and index.
+- `toLock` - The lock script of the new owner/recipient of the spore.
+
+## Extras
+
+### Code example
+
+For a valid on-chain transaction, you'll need to sign the transaction and send it to the chain.
+
+Here's a code example for how to transfer a spore with [`CKB default lock`](https://github.com/nervosnetwork/ckb-system-scripts/blob/master/c/secp256k1_blake160_sighash_all.c):
+
+<EmbedCard
+  title="transferSpore.ts"
+  href="https://github.com/sporeprotocol/spore-sdk/blob/b3e5e9c8f0243567d6eb06f1b759b3e4829bacb9/examples/secp256k1/apis/transferSpore.ts"
+  description="Transfer a Spore "
+  className="margin-top--sm"
+/>
+


### PR DESCRIPTION
- Melt Spore
- Transfer Spore/Cluster
- Disable Zero-fee Transfer
- Modify Zero-fee Transfer (post creation)
- added "Modify Zero-fee Transfer" under extra of "Create Spore"

Rearranged order scheme to Create/Transfer/Melt/Data from Spore/Cluster