### PR TITLE
Update discord invite link

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -83,7 +83,7 @@ const config = {
             items: [
               {
                 label: 'Discord',
-                href: 'https://discord.gg/9eufnpZZ8P',
+                href: 'https://discord.gg/X7D7xG7YeX',
               },
               {
                 label: 'Email',


### PR DESCRIPTION
the previous link leads to an archived channel